### PR TITLE
Refactor verification to handle passing multiple cert pools

### DIFF
--- a/sign_test.go
+++ b/sign_test.go
@@ -33,13 +33,8 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
 		}
-
 		truststore := x509.NewCertPool()
 		truststore.AddCert(rootCert.Certificate)
-		opts := x509.VerifyOptions{
-			Roots: truststore,
-		}
-
 		for _, sigalginter := range sigalgs {
 			interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate Cert", rootCert, sigalginter, true)
 			if err != nil {
@@ -84,7 +79,7 @@ func TestSign(t *testing.T) {
 					if !bytes.Equal(content, p7.Content) {
 						t.Errorf("test %s/%s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalginter, sigalgsigner, content, p7.Content)
 					}
-					if err := p7.VerifyWithChain(opts); err != nil {
+					if err := p7.VerifyWithChain(truststore); err != nil {
 						t.Errorf("test %s/%s/%s: cannot verify signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
 					if !signerDigest.Equal(p7.Signers[0].DigestAlgorithm.Algorithm) {
@@ -180,13 +175,8 @@ func TestSignWithoutAttributes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
 		}
-
 		truststore := x509.NewCertPool()
 		truststore.AddCert(rootCert.Certificate)
-		opts := x509.VerifyOptions{
-			Roots: truststore,
-		}
-
 		for _, sigalgsigner := range sigalgs {
 			signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", rootCert, sigalgsigner, false)
 			if err != nil {
@@ -224,7 +214,7 @@ func TestSignWithoutAttributes(t *testing.T) {
 				if !bytes.Equal(content, p7.Content) {
 					t.Errorf("test %s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalgsigner, content, p7.Content)
 				}
-				if err := p7.VerifyWithChain(opts); err != nil {
+				if err := p7.VerifyWithChain(truststore); err != nil {
 					t.Errorf("test %s/%s: cannot verify signed data: %s", sigalgroot, sigalgsigner, err)
 				}
 				if !signerDigest.Equal(p7.Signers[0].DigestAlgorithm.Algorithm) {

--- a/sign_test.go
+++ b/sign_test.go
@@ -33,8 +33,13 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
 		}
+
 		truststore := x509.NewCertPool()
 		truststore.AddCert(rootCert.Certificate)
+		opts := x509.VerifyOptions{
+			Roots: truststore,
+		}
+
 		for _, sigalginter := range sigalgs {
 			interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate Cert", rootCert, sigalginter, true)
 			if err != nil {
@@ -79,7 +84,7 @@ func TestSign(t *testing.T) {
 					if !bytes.Equal(content, p7.Content) {
 						t.Errorf("test %s/%s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalginter, sigalgsigner, content, p7.Content)
 					}
-					if err := p7.VerifyWithChain(truststore); err != nil {
+					if err := p7.VerifyWithChain(opts); err != nil {
 						t.Errorf("test %s/%s/%s: cannot verify signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
 					if !signerDigest.Equal(p7.Signers[0].DigestAlgorithm.Algorithm) {
@@ -175,8 +180,13 @@ func TestSignWithoutAttributes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
 		}
+
 		truststore := x509.NewCertPool()
 		truststore.AddCert(rootCert.Certificate)
+		opts := x509.VerifyOptions{
+			Roots: truststore,
+		}
+
 		for _, sigalgsigner := range sigalgs {
 			signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", rootCert, sigalgsigner, false)
 			if err != nil {
@@ -214,7 +224,7 @@ func TestSignWithoutAttributes(t *testing.T) {
 				if !bytes.Equal(content, p7.Content) {
 					t.Errorf("test %s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalgsigner, content, p7.Content)
 				}
-				if err := p7.VerifyWithChain(truststore); err != nil {
+				if err := p7.VerifyWithChain(opts); err != nil {
 					t.Errorf("test %s/%s: cannot verify signed data: %s", sigalgroot, sigalgsigner, err)
 				}
 				if !signerDigest.Equal(p7.Signers[0].DigestAlgorithm.Algorithm) {

--- a/verify.go
+++ b/verify.go
@@ -72,6 +72,11 @@ func (p7 *PKCS7) VerifyWithChainAtTime(truststore *x509.CertPool, currentTime ti
 // authenticated attr it verifies the chain at that time and UTC now
 // otherwise.
 func (p7 *PKCS7) VerifyWithOpts(opts x509.VerifyOptions) (err error) {
+	// if KeyUsage isn't set, default to ExtKeyUsageAny
+	if opts.KeyUsages == nil {
+		opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+	}
+
 	if len(p7.Signers) == 0 {
 		return errors.New("pkcs7: Message has no signers")
 	}

--- a/verify.go
+++ b/verify.go
@@ -14,7 +14,7 @@ import (
 // trust store, effectively disabling certificate verification when validating
 // a signature.
 func (p7 *PKCS7) Verify() (err error) {
-	return p7.VerifyWithChain(x509.VerifyOptions{})
+	return p7.VerifyWithChain(nil)
 }
 
 // VerifyWithChain checks the signatures of a PKCS7 object.
@@ -22,18 +22,20 @@ func (p7 *PKCS7) Verify() (err error) {
 // If truststore is not nil, it also verifies the chain of trust of
 // the end-entity signer cert to one of the roots in the
 // truststore. When the PKCS7 object includes the signing time
-// authenticated attr verifies the chain at that time and UTC now
+// authenticated attr it verifies the chain at that time and UTC now
 // otherwise.
-func (p7 *PKCS7) VerifyWithChain(opts x509.VerifyOptions) (err error) {
-	if len(p7.Signers) == 0 {
-		return errors.New("pkcs7: Message has no signers")
+func (p7 *PKCS7) VerifyWithChain(truststore *x509.CertPool) (err error) {
+	intermediates := x509.NewCertPool()
+	for _, cert := range(p7.Certificates) {
+		intermediates.AddCert(cert)
 	}
-	for _, signer := range p7.Signers {
-		if err := verifySignature(p7, signer, opts); err != nil {
-			return err
-		}
+
+	opts := x509.VerifyOptions{
+		Roots: truststore,
+		Intermediates: intermediates,
 	}
-	return nil
+
+	return p7.VerifyWithOpts(opts)
 }
 
 // VerifyWithChainAtTime checks the signatures of a PKCS7 object.
@@ -42,12 +44,39 @@ func (p7 *PKCS7) VerifyWithChain(opts x509.VerifyOptions) (err error) {
 // the end-entity signer cert to a root in the truststore at
 // currentTime. It does not use the signing time authenticated
 // attribute.
-func (p7 *PKCS7) VerifyWithChainAtTime(opts x509.VerifyOptions) (err error) {
+func (p7 *PKCS7) VerifyWithChainAtTime(truststore *x509.CertPool, currentTime time.Time) (err error) {
+	intermediates := x509.NewCertPool()
+	for _, cert := range(p7.Certificates) {
+		intermediates.AddCert(cert)
+	}
+
+	opts := x509.VerifyOptions{
+		Roots: truststore,
+		Intermediates: intermediates,
+		CurrentTime: currentTime,
+	}
+
+	return p7.VerifyWithOpts(opts)
+}
+
+// VerifyWithOpts checks the signatures of a PKCS7 object.
+//
+// It accepts x509.VerifyOptions as a parameter.
+// This struct contains a root certificate pool, an intermedate certificate pool, 
+// an optional list of EKUs, and an optional time that certificates should be
+// checked as being valid during.
+
+// If VerifyOpts.Roots is not nil it verifies the chain of trust of
+// the end-entity signer cert to one of the roots in the
+// truststore. When the PKCS7 object includes the signing time
+// authenticated attr it verifies the chain at that time and UTC now
+// otherwise.
+func (p7 *PKCS7) VerifyWithOpts(opts x509.VerifyOptions) (err error) {
 	if len(p7.Signers) == 0 {
 		return errors.New("pkcs7: Message has no signers")
 	}
 	for _, signer := range p7.Signers {
-		if err := verifySignatureAtTime(p7, signer, opts); err != nil {
+		if err := verifySignature(p7, signer, opts); err != nil {
 			return err
 		}
 	}

--- a/verify.go
+++ b/verify.go
@@ -80,8 +80,21 @@ func (p7 *PKCS7) VerifyWithOpts(opts x509.VerifyOptions) (err error) {
 	if len(p7.Signers) == 0 {
 		return errors.New("pkcs7: Message has no signers")
 	}
+
+	// if opts.CurrentTime is not set, call verifySignature,
+	// which will verify the leaf certificate with the current time
+	if opts.CurrentTime.IsZero() {
+		for _, signer := range p7.Signers {
+			if err := verifySignature(p7, signer, opts); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	// if opts.CurrentTime is set, call verifySignatureAtTime,
+	// which will verify the leaf certificate with opts.CurrentTime
 	for _, signer := range p7.Signers {
-		if err := verifySignature(p7, signer, opts); err != nil {
+		if err := verifySignatureAtTime(p7, signer, opts); err != nil {
 			return err
 		}
 	}

--- a/verify_test.go
+++ b/verify_test.go
@@ -247,8 +247,12 @@ func TestVerifyFirefoxAddon(t *testing.T) {
 	p7.Content = FirefoxAddonContent
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(FirefoxAddonRootCert)
+	opts := x509.VerifyOptions{
+		Roots: certPool,
+	}
+
 	// verifies at the signingTime authenticated attr
-	if err := p7.VerifyWithChain(certPool); err != nil {
+	if err := p7.VerifyWithChain(opts); err != nil {
 		t.Errorf("Verify failed with error: %v", err)
 	}
 
@@ -258,16 +262,21 @@ func TestVerifyFirefoxAddon(t *testing.T) {
 	// Intermediate: 2015-03-17 23:52:42 +0000 UTC 2025-03-14 23:52:42 +0000 UTC
 	// Root:         2015-03-17 22:53:57 +0000 UTC 2025-03-14 22:53:57 +0000 UTC
 	validTime := time.Date(2021, 8, 16, 20, 0, 0, 0, time.UTC)
-	if err = p7.VerifyWithChainAtTime(certPool, validTime); err != nil {
+	opts.CurrentTime = validTime
+
+	if err = p7.VerifyWithChainAtTime(opts); err != nil {
 		t.Errorf("Verify at UTC now failed with error: %v", err)
 	}
 
 	expiredTime := time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)
-	if err = p7.VerifyWithChainAtTime(certPool, expiredTime); err == nil {
+	opts.CurrentTime = expiredTime
+	if err = p7.VerifyWithChainAtTime(opts); err == nil {
 		t.Errorf("Verify at expired time %s did not error", expiredTime)
 	}
+
 	notYetValidTime := time.Date(1999, time.July, 5, 0, 13, 0, 0, time.UTC)
-	if err = p7.VerifyWithChainAtTime(certPool, notYetValidTime); err == nil {
+	opts.CurrentTime = notYetValidTime
+	if err = p7.VerifyWithChainAtTime(opts); err == nil {
 		t.Errorf("Verify at not yet valid time %s did not error", notYetValidTime)
 	}
 
@@ -278,7 +287,15 @@ func TestVerifyFirefoxAddon(t *testing.T) {
 		t.Errorf("No end-entity certificate found for signer")
 	}
 	signingTime := mustParseTime("2017-02-23T09:06:16-05:00")
-	chains, err := verifyCertChain(ee, p7.Certificates, certPool, signingTime)
+	opts.CurrentTime = signingTime
+
+	intermediates := x509.NewCertPool()
+	for _, cert := range(p7.Certificates) {
+		intermediates.AddCert(cert)
+	}
+	opts.Intermediates = intermediates
+
+	chains, err := ee.Verify(opts)
 	if err != nil {
 		t.Error(err)
 	}
@@ -559,7 +576,11 @@ but that's not what ships are built for.
 				if err != nil {
 					t.Fatalf("Parse encountered unexpected error: %v", err)
 				}
-				if err := p7.VerifyWithChain(truststore); err != nil {
+
+				opts := x509.VerifyOptions{
+					Roots: truststore,
+				}
+				if err := p7.VerifyWithChain(opts); err != nil {
 					t.Fatalf("Verify failed with error: %v", err)
 				}
 				// Verify the certificate chain to make sure the identified root
@@ -568,7 +589,15 @@ but that's not what ships are built for.
 				if ee == nil {
 					t.Fatalf("No end-entity certificate found for signer")
 				}
-				chains, err := verifyCertChain(ee, p7.Certificates, truststore, time.Now())
+
+				opts.CurrentTime = time.Now()
+				intermediates := x509.NewCertPool()
+				for _, cert := range(p7.Certificates) {
+					intermediates.AddCert(cert)
+				}
+				opts.Intermediates = intermediates
+			
+				chains, err := ee.Verify(opts)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Signed-off-by: Meredith Lancaster <malancas@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Add a new method `PKCS7#VerifyWithOpts`. This contains the logic previously found in `PKCS7#VerifyWithChain`. This method takes the `x509.VerifyOptions` struct as an argument instead a single `x509.CertificatePool`. This allows us to pass the root certificates, intermediates certificates, and an EKU list separately instead of just a single certificate pool.

The `PKCS7#VerifyWithChain` and `PKCS7#VerifyWithChainAtTime` methods now call  `PKCS7#VerifyWithOpts` 

The `verifySignature` function called by `PKCS7#VerifyWithChain` no longer calls `verifyCertChain`, which created an instance of `x509.VerifyOptions` with separate root and intermediate certificate pools. Instead `PKCS7#VerifyWithChain` calls the `x509.Certificate.Verify` method directly since it already has an instance of `VerifyOptions`.

The `verifySignatureAtTime` function has been updated the same way.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->